### PR TITLE
CloudWatchLogsTarget no longer require to insert credentials.

### DIFF
--- a/NLog.Targets.CloudWatchLogs/CloudWatchLogsTarget.cs
+++ b/NLog.Targets.CloudWatchLogs/CloudWatchLogsTarget.cs
@@ -15,14 +15,43 @@ namespace NLog.Targets.CloudWatchLogs
     {
         private Lazy<CloudWatchLogsClientWrapper> _client;
 
-        public CloudWatchLogsTarget()
+        //public CloudWatchLogsTarget()
+        //{
+        //    _client = new Lazy<CloudWatchLogsClientWrapper>(() => 
+        //        new CloudWatchLogsClientWrapper(
+        //            new AmazonCloudWatchLogsClient(AWSAccessKeyId, AWSSecretKey, RegionEndpoint.GetBySystemName(AWSRegion)),
+        //            LogGroupName,
+        //            LogStreamName,
+        //            new ExponentialInterval<Seconds>(2)));
+        //}
+
+        public CloudWatchLogsTarget(bool localCredentials = false)
         {
-            _client = new Lazy<CloudWatchLogsClientWrapper>(() => 
-                new CloudWatchLogsClientWrapper(
-                    new AmazonCloudWatchLogsClient(AWSAccessKeyId, AWSSecretKey, RegionEndpoint.GetBySystemName(AWSRegion)),
-                    LogGroupName,
-                    LogStreamName,
-                    new ExponentialInterval<Seconds>(2)));
+            if (localCredentials)
+                _client = new Lazy<CloudWatchLogsClientWrapper>(() =>
+                    new CloudWatchLogsClientWrapper(
+                        new AmazonCloudWatchLogsClient(AWSAccessKeyId, AWSSecretKey,
+                            RegionEndpoint.GetBySystemName(AWSRegion)),
+                        LogGroupName,
+                        LogStreamName,
+                        new ExponentialInterval<Seconds>(2)));
+            else
+            {
+                if (string.IsNullOrEmpty(AWSRegion))
+                    _client = new Lazy<CloudWatchLogsClientWrapper>(() =>
+                        new CloudWatchLogsClientWrapper(
+                            new AmazonCloudWatchLogsClient(),
+                            LogGroupName,
+                            LogStreamName,
+                            new ExponentialInterval<Seconds>(2)));
+                else
+                    _client = new Lazy<CloudWatchLogsClientWrapper>(() =>
+                        new CloudWatchLogsClientWrapper(
+                            new AmazonCloudWatchLogsClient(RegionEndpoint.GetBySystemName(AWSRegion)),
+                            LogGroupName,
+                            LogStreamName,
+                            new ExponentialInterval<Seconds>(2)));
+            }
         }
 
         [RequiredParameter]

--- a/NLog.Targets.CloudWatchLogs/CloudWatchLogsTarget.cs
+++ b/NLog.Targets.CloudWatchLogs/CloudWatchLogsTarget.cs
@@ -54,13 +54,13 @@ namespace NLog.Targets.CloudWatchLogs
             }
         }
 
-        [RequiredParameter]
+        //[RequiredParameter]
         public string AWSAccessKeyId { get; set; }
 
-        [RequiredParameter]
+        //[RequiredParameter]
         public string AWSSecretKey { get; set; }
 
-        [RequiredParameter]
+        //[RequiredParameter]
         public string AWSRegion { get; set; }
 
         [RequiredParameter]


### PR DESCRIPTION
Issue #10 
Use Cases:
-CloudWatchLogsTarget() without credentials (Flexible to set AWS Region)
-CloudWatchLogsTarget(true) with credentials